### PR TITLE
Add wrapper methods random and forward feature selection

### DIFF
--- a/R/FeatureSelection.R
+++ b/R/FeatureSelection.R
@@ -1,0 +1,80 @@
+#' @title Abstract FeatureSelection Class
+#'
+#' @description `FeatureSelection` class that implements the main functionality each fs must have. A fs is an object that describes the optimization method for choosing the features given within the `[PerformanceEvaluator]` object.
+#'
+#' @section Usage:
+#' ```
+#' # Construction
+#' fs = FeatureSelectionr$new(id, pe, tm, settings = list())
+#'
+#' # public members
+#' fs$id
+#' fs$pe
+#' fs$tm
+#' fs$settings
+#'
+#' # public methods
+#' fs$calculate()
+#' ```
+#' @section Arguments:
+#' * `id` (`character(1)`):\cr
+#'   The id of the FeatureSelection.
+#' * `pe` (`[PerformanceEvaluator]`).
+#' * `tm` (`[Terminator]`).
+#' * `settings` (`list`):\cr
+#'   The settings for the FeatureSelection.
+#'
+#' @section Details:
+#' * `$new()` creates a new object of class `[FeatureSelection]`.
+#' * `id` stores an identifier for this `[FeatureSelection]`.
+#' * `pe` stores the [PerformanceEvaluator] to optimize.
+#' * `tm` stores the `[Terminator]`.
+#' * `settings` is a list of settings for this `[FeatureSelection]`.
+#' * `calculate()` performs the feature selection, until the budget of the `[Terminator]` in the `[PerformanceEvaluator]` is exhausted.
+#' @name FeatureSelection
+#' @family FeatureSelection
+NULL
+
+#' @export
+FeatureSelection = R6Class("FeatureSelection",
+   public = list(
+      id = NULL,
+      pe = NULL,
+      tm = NULL,
+      settings = NULL,
+      state = NULL,
+
+      initialize = function(id, pe, tm, settings = list()) {
+         self$id = checkmate::assert_string(id)
+         self$pe = checkmate::assert_r6(pe, "PerformanceEvaluator")
+         self$tm = checkmate::assert_r6(tm, "Terminator")
+         self$settings = checkmate::assert_list(settings, names = "unique")
+         },
+
+      calculate = function() {
+         while(!self$tm$terminated) {
+            private$calculate_step()
+         }
+      }
+  ),
+   private = list(
+      calculate_step = function() {
+         states = private$generate_states()
+         named_states = lapply(states, private$binary_to_features)
+
+         private$eval_states_terminator(named_states)
+
+         bmr = self$pe$get_best()
+         features = bmr[[length(bmr)]]$features
+         self$state = as.numeric(Reduce("|", lapply(features, function(x) x == self$pe$task$feature_names)))
+      },
+      binary_to_features = function(binary_features) {
+         task$feature_names[as.logical(binary_features)]
+      },
+      eval_states_terminator = function(states) {
+         self$tm$update_start(self$pe)
+         self$pe$eval_states(states)
+         self$tm$update_end(self$pe)
+      }
+ )
+)

--- a/R/FeatureSelectionForward.R
+++ b/R/FeatureSelectionForward.R
@@ -1,0 +1,70 @@
+#' @title FeatureSelectionForward
+#'
+#' @description
+#' FeatureSelection child class to conduct forward search.
+#'
+#' @section Usage:
+#'  ```
+#' fs = FeatureSelectionForward$new()
+#' ```
+#' See [FeatureSelection] for a description of the interface.
+#'
+#' @section Arguments:
+#' * `pe` (`[PerformanceEvaluator]`).
+#' * `tm` (`[Terminator]`).
+#' * `max_features` (`integer(1)`)
+#'   Maximum number of features
+#'
+#' @section Details:
+#' `$new()` creates a new object of class [FeatureSelectionForward].
+#' `$get_result()` Returns selected features in each step.
+#' The interface is described in [FeatureSelection].
+#'
+#' Each step is possibly executed in parallel via [mlr3::benchmark()]
+#'
+#' @name FeatureSelectionForward
+#' @family FeatureSelection
+NULL
+
+#' @export
+#' @include FeatureSelection.R
+
+FeatureSelectionForward = R6Class("FeatureSelectionRandom",
+   inherit = FeatureSelection,
+   public = list(
+      initialize = function(pe, tm, max_features = NA) {
+         super$initialize(id = "forward_selection", pe = pe, tm = tm,
+                           settings = list(max_features = checkmate::assert_numeric(max_features,
+                                                                                    lower = 1,
+                                                                                    upper = length(pe$task$feature_names))))
+
+         self$state = rep(0, length(pe$task$feature_names))
+     },
+
+     get_result = function() {
+        bmr = lapply(self$pe$bmr, function(bmr) bmr$get_best(self$pe$task$measures[[1L]]$id))
+        lapply(bmr, function(x) x$task$feature_names)
+     },
+     get_optimization_path = function() {
+        mapply(function(bmr, states) {
+           performance = as.data.table(bmr$aggregated())[,self$pe$task$measures[[1]]$id, with=FALSE]
+           features = t(as.data.table(states))
+           data.table::setorderv(cbind(performance, features), self$pe$task$measures[[1]]$id, order=-1)
+
+        }, bmr=self$pe$bmr, states=self$pe$states)
+     }
+   ),
+   private = list(
+      generate_states = function() {
+         new_states = list()
+         for (i in seq_along(self$state)) {
+            if (self$state[i] == 0) {
+            state = self$state
+            state[i] = 1
+            new_states[[length(new_states) + 1]] = state
+            }
+         }
+         new_states
+      }
+   )
+)

--- a/R/FeatureSelectionRandom.R
+++ b/R/FeatureSelectionRandom.R
@@ -1,0 +1,70 @@
+#' @title FeatureSelectionRandom
+#'
+#' @description
+#' FeatureSelection child class to conduct random search
+#'
+#' @section Usage:
+#'  ```
+#' fs = FeatureSelectionRandom$new()
+#' ```
+#' See [FeatureSelection] for a description of the interface.
+#'
+#' @section Arguments:
+#' * `pe` (`[PerformanceEvaluator]`).
+#' * `tm` (`[Terminator]`).
+#' * `max_features` (`integer(1)`)
+#'   Maximum number of features
+#' * `batch_size` (`integer(1`):
+#'   Maximum number of feature combinations to try in a batch.
+#'   Each batch is possibly executed in parallel via [mlr3::benchmark()].
+#'
+#' @section Details:
+#' `$new()` creates a new object of class [FeatureSelectionRandom].
+#' `$get_result()` Returns best feature combination.
+#' The interface is described in [FeatureSelection].
+#'
+#' @name FeatureSelectionRandom
+#' @family FeatureSelection
+NULL
+
+#' @export
+#' @include FeatureSelection.R
+
+FeatureSelectionRandom = R6Class("FeatureSelectionRandom",
+  inherit = FeatureSelection,
+  public = list(
+     initialize = function(id, pe, tm, max_features = NA, batch_size = 10) {
+        super$initialize(id = "random_selection", pe = pe, tm = tm,
+                         settings = list(max_features = checkmate::assert_numeric(max_features,
+                                                                                  lower = 1,
+                                                                                  upper = length(pe$task$feature_names)),
+                                         batch_size = checkmate::assert_numeric(batch_size)))
+     },
+
+   get_result = function() {
+      if(length(self$pe$bmr) > 1) {
+         bmr = lapply(self$pe$bmr[2:length(self$pe$bmr)], function(bmr) self$pe$bmr[[1]]$combine(bmr))
+      } else {
+         bmr = self$pe$bmr
+      }
+      bmr_best = bmr[[length(bmr)]]$get_best(self$pe$task$measures[[1L]]$id)
+      bmr_best$task$feature_names
+
+   }
+  ),
+  private = list(
+   generate_states = function() {
+     lapply(seq_len(self$settings$batch_size), function(i) {
+       if(is.na(self$settings$max_features)) {
+         return(rbinom(length(self$pe$task$feature_names), 1, 0.5))
+       }
+        x = Inf
+        while (sum(x) >= self$settings$max_features) {
+           x = rbinom(length(self$pe$task$feature_names), 1, 0.5)
+        }
+        return(x)
+     }
+     )
+     }
+   )
+  )

--- a/R/PerformanceEvaluator.R
+++ b/R/PerformanceEvaluator.R
@@ -1,0 +1,84 @@
+#' @title Abstract PerformanceEvaluator Class
+#'
+#' @description
+#' `PerformanceEvaluator` class that implements the performance evaluation on a set of feature combinations. A pe is an object that stores all informations that are necesarry to conduct a feature selection (`mlr3::Task`, `mlr3::Learner`, `mlr3::Resampling`).
+#'
+#' @section Usage:
+#' ```
+#' # Construction
+#' pe = PerformanceEvaluator$new()
+#'
+#' # Public members
+#' pe$task
+#' pe$learner
+#' pe$resampling
+#' pe$bmr
+#'
+#' # Public methods
+#' pe$eval_states(states)
+#' pe$get_best()
+#' ```
+#'
+#' @section Arguments:
+#' * `task` (`mlr3::Task`):
+#'   The task that we want to evaluate.
+#' * `learner` (`mlr3::Learner`):
+#'   The learner that we want to evaluate.
+#' * `resampling` (`mlr3::Resampling`):
+#'   The Resampling method that is used to evaluate the learner.
+#'
+#' @section Details:
+#' * `$new()` creates a new object of class [PerformanceEvaluator].
+#' * `$task` (`mlr3::Task`) the task for which the feature selection should be conducted.
+#' * `$learner` (`mlr3::Learner`) the algorithm for which the feature selection should be conducted.
+#' * `$resampling` (`mlr3::Resampling`) strategy to evaluate a feature combination
+#' * `$bmr` (`list`) of (`mlr3::BenchmarkResult`) objects. Each entry corresponds to one batch or step depending one the used feature selection method.
+#' * `eval_states(states)` evaluates the feature combinations `states`
+#' * `get_best()` returns selected features with the best performance of each entry in `$bmr`
+#'
+#' @name PerformanceEvaluator
+#' @keywords internal
+#' @family PerformanceEvaluator
+NULL
+
+#' @export
+PerformanceEvaluator = R6Class("PerformanceEvaluator",
+  public = list(
+    task = NULL,
+    learner = NULL,
+    resampling = NULL,
+    bmr = list(),
+    states = list(),
+
+    initialize = function(task, learner, resampling) {
+      self$task = mlr3::assert_task(task)
+      self$learner = mlr3::assert_learner(learner, task = task)
+      self$resampling = mlr3::assert_resampling(resampling)
+    },
+
+    eval_states = function(states) {
+      self$states[[length(self$states)+1]] <- states
+      # For each state, clone task and set feature subset
+      task_list <- list()
+      for(state in states) {
+        task = self$task$clone()
+        task$select(state)
+        task_list[[length(task_list)+1]] <- task
+      }
+
+      new_bmr = benchmark(data.table::data.table(task = task_list,
+                                     learner = list(self$learner),
+                                     resampling = list(self$resampling)))
+
+      self$bmr[[length(self$bmr)+1]] <- new_bmr
+    },
+
+    get_best = function() {
+      lapply(self$bmr, function(x) {
+        rr = x$get_best(self$task$measures[[1L]]$id)
+        list(features = rr$task$feature_names,
+             performance = mean(rr$performance(self$task$measures[[1L]]$id)))
+      })
+    }
+  )
+)

--- a/R/Terminator.R
+++ b/R/Terminator.R
@@ -1,0 +1,50 @@
+#' @title Abstract Terminator Class
+#'
+#' @description Abstract `Terminator` class that implements the main functionality each terminator must have. A terminator is an object that says when to stop the feature selection.
+#'
+#' @section Usage:
+#' ```
+#' # Construction
+#' tm = Terminator$new()
+#'
+#' # Public members
+#' tm$terminated
+#' tm$state
+#'
+#' # Public methods
+#' tm$update_state(pe)
+#' tm$update_end(pe)
+#' ```
+#'
+#' @section Arguments:
+#' * `pe` (`PerformanceEvaluator`):
+#'   `PerformanceEvaluator` object used to determine when to stop the tuning.
+#'
+#' @section Details:
+#' * `$new()` creates a new object of class [Terminator].
+#' * `$terminated` (`logical(1)`) is the termination criterion met? Updated by each call of `update_start()`/`update_end()`.
+#' * `$settings` (`list()`) settings that are set by the child classes to define stopping criteria.
+#' * `$state` (`list()`) arbitrary state of the Terminator. Gets updated with each call of `update_start()` and `update_end()`.
+#' * `$update_start()` is called in each tuning iteration before the evaluation.
+#' * `$update_end()` is called in each tuning iteration after the evaluation.
+NULL
+
+#' @export
+Terminator = R6Class("Terminator",
+  public = list(
+    terminated = NULL,
+    settings = NULL,
+    state = NULL,
+
+    initialize = function(settings) {
+      self$settings = checkmate::assert_list(settings, names = "unique")
+    },
+
+    update_start = function(pe) {
+      stop("$update_start() not implemented for Terminator")
+    },
+    update_end = function(pe) {
+      stop("$update_end() not implemented for Terminator")
+    }
+  )
+)

--- a/R/TerminatorEvaluations.R
+++ b/R/TerminatorEvaluations.R
@@ -1,0 +1,56 @@
+#' @title TerminatorEvaluations
+#'
+#' @description
+#' Terminator child class to terminate the feature selection if the model performance does not improve to a specified threshold in the next step.
+#'
+#' @section Usage:
+#'  ```
+#' tm = TerminatorEvaluations$new()
+#' ```
+#' See [Terminator] for a description of the interface.
+#'
+#' @section Arguments:
+#' * `max_evaluations` (`integer(1)`):
+#'   Maximum number of function evaluations.
+#'
+#' @section Details:
+#' `$new()` creates a new object of class [TerminatorEvaluations].
+#'
+#' The interface is described in [Terminator].
+#'
+#' @name TerminatorEvaluations
+#' @family Terminator
+#' @examples
+#' t = TerminatorEvaluations$new(max_evaluations = 100)
+NULL
+
+#' @export
+#' @include Terminator.R
+TerminatorEvaluations = R6Class("TerminatorEvaluations",
+  inherit = Terminator,
+  public = list(
+    evaluations = NULL,
+
+    initialize = function(max_evaluations) {
+      super$initialize(settings = list(max_evaluations = checkmate::assert_count(max_evaluations, positive = TRUE, coerce = TRUE)))
+
+      self$state = list(evals = 0L)
+      self$terminated = FALSE
+    },
+
+    update_start = function(pe) {
+      if (length(pe$bmr) < 1) {
+        self$state$evals = 0L
+      } else {
+        row_num = lapply(pe$bmr, function(bmr) nrow(bmr$aggregated()))
+        self$state$evals = Reduce("sum", row_num)
+      }
+      self$terminated = (self$state$evals >= self$settings$max_evaluations)
+      invisible(self)
+    },
+
+    update_end = function(pe) {
+      self$update_start(pe)
+    }
+  )
+)

--- a/R/TerminatorPerformanceStep.R
+++ b/R/TerminatorPerformanceStep.R
@@ -1,0 +1,66 @@
+#' @title TerminatorPerformanceStep
+#'
+#' @description
+#' Terminator child class to terminate the sequential feature selection if the model performance does not improve to a specified threshold in the next step.
+#'
+#' @section Usage:
+#'  ```
+#' tm = TerminatorPerformanceStep$new(threshold)
+#' ```
+#' See [Terminator] for a description of the interface.
+#'
+#' @section Arguments:
+#' * `threshold` (`numeric(1)``):
+#' The feature selection is terminated if the performance improvement between two steps is less than the threshold.
+#'
+#' @section Details:
+#' `$new()` creates a new object of class [TerminatorPerformanceStep].
+#'
+#' The interface is described in [Terminator].
+#'
+#' @name TerminatorPerformanceStep
+#' @family Terminator
+#' @examples
+#' t = TerminatorPerformanceStep$new(threshold = 0.01)
+NULL
+
+#' @export
+#' @include Terminator.R
+TerminatorPerformanceStep = R6Class("TerminatorPerformanceStep",
+  inherit = Terminator,
+  public = list(
+    threshold = NULL,
+
+    initialize = function(threshold) {
+      super$initialize(settings = list(threshold = checkmate::assert_numeric(threshold)))
+
+      self$terminated = FALSE
+      self$state = list(step_performance = NA)
+    },
+
+    update_start = function(pe) {
+      invisible(self)
+    },
+    update_end = function(pe) {
+      bmr = pe$get_best()
+      # Stop if all features are included
+      if(length(pe$bmr) == length(pe$task$feature_names)) {
+        self$terminated = TRUE
+      }
+
+      if(!is.na(self$state$step_performance)) {
+        if(pe$task$measures[[1]]$minimize) {
+          if(self$state$step_performance - bmr[[length(bmr)]]$performance <= self$settings$threshold) {
+            self$terminated = TRUE
+          }
+        } else {
+          if(bmr[[length(bmr)]]$performance - self$state$step_performance <= self$settings$threshold) {
+            self$terminated = TRUE
+          }
+        }
+      }
+      self$state$step_performance = bmr[[length(bmr)]]$performance
+      invisible(self)
+    }
+  )
+)


### PR DESCRIPTION
fixes #24 

This is a basic implementation of mlr’s `makeFeatSelControlRandom` and `makeFeatSelControlSequential`. The overall design is similar to `mlr3tuning`. I used many descriptions and some parts of the code from this package.

### Classes

`FeatureSelection*`
* Implements the `generate_states` method that generates different feature combinations (states) in a 0-1 encoding.
  * For `FeatureSelectionRandom` n combinations are generated depending on the `batch_size`.
  * For `FeatureSelectionForward` all combinations of one step are generated.

`PerformanceEvaluator`
* Implements the `evaluate_states` method that takes the states as an argument. For each state, the task with all features is cloned and a selection is applied based on the encoding of the state. All states are evaluated with `mlr3::benchmark`.
* For each call of `evaluate_states`, the `states` are stored in a list entry in `self$states`.
* For each call of `evaluate_states`, the `benchmark` object is stored in a list entry in `self$bmr`.
* The storing in list entries is necessary so that `FeatureSelectionForward` is able to generate the path of the stepwise selection.

`Terminator`
* Works similar to the `Terminator` class in `mlr3tuning`.
* `TerminatorPerformanceStep` is specially designed to work with `FeatureSelectionForward`. It compares the last two chosen states and terminates if the performance improvement is under a certain threshold.

### Discussion
* We need to come up with an idea how to present the results. At the moment there are just two basic functions `get_result` and `get_optimization_path` which print out the best feature combination or the steps of the feature selection.
* Does it make sense to have the helper function `binary_to_features`, which converts the 0-1 encoding to feature names as a private method in `FeatureSelection`?
* `max_features` is not implemented for `FeatureSelectionForward` because it is something the `TerminatorPerformanceStep` object needs to know. I need to come up with an elegant way to do this. Maybe we have to make `max_features` an argument for ` TerminatorPerformanceStep` and remove it as a setting for `FeatureSelectionForward`.

