### PR TITLE
Rename generic filter hyperpars to align with mlr3pipelines

### DIFF
--- a/R/Filter.R
+++ b/R/Filter.R
@@ -69,10 +69,10 @@
 #'   Filters the [Task] by reference, keeps `frac` fracent of the features
 #'   (rounded via [base::round()]).
 #'
-#'   * `filter_thresh(task, thresh)`\cr
+#'   * `filter_cutoff(task, cutoff)`\cr
 #'   ([Task], `numeric(1)`) -> [Task]\cr
 #'   Filters the [Task] by reference, keeps features whose filter score values
-#'   exceeds `thresh`.
+#'   exceeds `cutoff`.
 #'
 #' @family Filter
 #' @export
@@ -175,24 +175,24 @@ Filter = R6Class("Filter",
       filter_n(self, task, round(task$ncol * frac))
     },
 
-    filter_thresh = function(task, threshold) {
+    filter_cutoff = function(task, cutoff) {
 
-      # check if thresh was supplied in any way
-      if (is.null(self$param_set$values$thresh) && missing(thresh)) {
-        stopf("No 'thresh' supplied. Either pass 'thresh' directly or define it during construction in the ParamSet.")
+      # check if cutoff was supplied in any way
+      if (is.null(self$param_set$values$cutoff) && missing(cutoff)) {
+        stopf("No 'cutoff' supplied. Either pass 'cutoff' directly or define it during construction in the ParamSet.")
       }
-      # check if thresh was supplied during construction AND in the function call
-      else if (!is.null(self$param_set$values$thresh) && !missing(thresh)) {
-        warningf("Taking the user supplied value of 'thresh' and ignoring the value set during construction.")
+      # check if cutoff was supplied during construction AND in the function call
+      else if (!is.null(self$param_set$values$cutoff) && !missing(cutoff)) {
+        warningf("Taking the user supplied value of 'cutoff' and ignoring the value set during construction.")
       }
-      # if construction value is missing and thresh is supplied, take thresh
-      else if (!is.null(self$param_set$values$thresh) && missing(thresh)) {
-        thresh = self$param_set$values$thresh
+      # if construction value is missing and cutoff is supplied, take cutoff
+      else if (!is.null(self$param_set$values$cutoff) && missing(cutoff)) {
+        cutoff = self$param_set$values$cutoff
       }
 
       assert_task(task)
-      assert_number(threshold)
-      filter_n(self, task, sum(self$scores > threshold))
+      assert_number(cutoffold)
+      filter_n(self, task, sum(self$scores > cutoffold))
     }
   )
 )

--- a/R/Filter.R
+++ b/R/Filter.R
@@ -64,9 +64,9 @@
 #'   ([Task], `integer(1)`) -> [Task]\cr
 #'   Filters the [Task] by reference, keeps up to `nfeat` features.
 #'
-#'   * `filter_perc(task, perc)`\cr
+#'   * `filter_frac(task, frac)`\cr
 #'   ([Task], `numeric(1)`) -> [Task]\cr
-#'   Filters the [Task] by reference, keeps `perc` percent of the features
+#'   Filters the [Task] by reference, keeps `frac` fracent of the features
 #'   (rounded via [base::round()]).
 #'
 #'   * `filter_thresh(task, thresh)`\cr
@@ -155,24 +155,24 @@ Filter = R6Class("Filter",
       filter_n(self, task, nfeat)
     },
 
-    filter_perc = function(task, perc) {
+    filter_frac = function(task, frac) {
 
-      # check if perc was supplied in any way
-      if (is.null(self$param_set$values$perc) && missing(perc)) {
-        stopf("No 'perc' supplied. Either pass 'perc' directly or define it during construction in the ParamSet.")
+      # check if frac was supplied in any way
+      if (is.null(self$param_set$values$frac) && missing(frac)) {
+        stopf("No 'frac' supplied. Either pass 'frac' directly or define it during construction in the ParamSet.")
       }
-      # check if perc was supplied during construction AND in the function call
-      else if (!is.null(self$param_set$values$perc) && !missing(perc)) {
-        warningf("Taking the user supplied value of 'perc' and ignoring the value set during construction.")
+      # check if frac was supplied during construction AND in the function call
+      else if (!is.null(self$param_set$values$frac) && !missing(frac)) {
+        warningf("Taking the user supplied value of 'frac' and ignoring the value set during construction.")
       }
-      # if construction value is missing and perc is supplied, take perc
-      else if (!is.null(self$param_set$values$perc) && missing(perc)) {
-        perc = self$param_set$values$perc
+      # if construction value is missing and frac is supplied, take frac
+      else if (!is.null(self$param_set$values$frac) && missing(frac)) {
+        frac = self$param_set$values$frac
       }
 
       assert_task(task)
-      assert_number(perc, lower = 0, upper = 1)
-      filter_n(self, task, round(task$ncol * perc))
+      assert_number(frac, lower = 0, upper = 1)
+      filter_n(self, task, round(task$ncol * frac))
     },
 
     filter_thresh = function(task, threshold) {

--- a/R/Filter.R
+++ b/R/Filter.R
@@ -60,9 +60,9 @@
 #'   and stores them in field `scores`. Some filter support partial scoring via
 #'   argument `n`.
 #'
-#'   * `filter_abs(task, abs)`\cr
+#'   * `filter_nfeat(task, nfeat)`\cr
 #'   ([Task], `integer(1)`) -> [Task]\cr
-#'   Filters the [Task] by reference, keeps up to `abs` features.
+#'   Filters the [Task] by reference, keeps up to `nfeat` features.
 #'
 #'   * `filter_perc(task, perc)`\cr
 #'   ([Task], `numeric(1)`) -> [Task]\cr
@@ -135,24 +135,24 @@ Filter = R6Class("Filter",
       invisible(self)
     },
 
-    filter_abs = function(task, abs) {
+    filter_nfeat = function(task, nfeat) {
 
-      # check if abs was supplied in any way
-      if (is.null(self$param_set$values$abs) && missing(abs)) {
-        stopf("No 'abs' supplied. Either pass 'abs' directly or define it during construction in the ParamSet.")
+      # check if nfeat was supplied in any way
+      if (is.null(self$param_set$values$nfeat) && missing(nfeat)) {
+        stopf("No 'nfeat' supplied. Either pass 'nfeat' directly or define it during construction in the ParamSet.")
       }
-      # check if abs was supplied during construction AND in the function call
-      else if (!is.null(self$param_set$values$abs) && !missing(abs)) {
-        warningf("Taking the user supplied value of 'abs' and ignoring the value set during construction.")
+      # check if nfeat was supplied during construction AND in the function call
+      else if (!is.null(self$param_set$values$nfeat) && !missing(nfeat)) {
+        warningf("Taking the user supplied value of 'nfeat' and ignoring the value set during construction.")
       }
-      # if construction value is missing and abs is supplied, take abs
-      else if (!is.null(self$param_set$values$abs) && missing(abs)) {
-        abs = self$param_set$values$abs
+      # if construction value is missing and nfeat is supplied, take nfeat
+      else if (!is.null(self$param_set$values$nfeat) && missing(nfeat)) {
+        nfeat = self$param_set$values$nfeat
       }
 
       assert_task(task)
-      assert_count(abs)
-      filter_n(self, task, abs)
+      assert_count(nfeat)
+      filter_n(self, task, nfeat)
     },
 
     filter_perc = function(task, perc) {

--- a/R/FilterAUC.R
+++ b/R/FilterAUC.R
@@ -27,7 +27,7 @@ FilterAUC = R6Class("FilterAUC", inherit = Filter,
         param_set = ParamSet$new(list(
           ParamInt$new("nfeat", lower = 1, tags = "generic"),
           ParamDbl$new("frac", lower = 0, upper = 1, tags = "generic"),
-          ParamDbl$new("thresh", tags = "generic")
+          ParamDbl$new("cutoff", tags = "generic")
         )),
         param_vals = param_vals
       )

--- a/R/FilterAUC.R
+++ b/R/FilterAUC.R
@@ -26,7 +26,7 @@ FilterAUC = R6Class("FilterAUC", inherit = Filter,
         task_properties = "twoclass",
         param_set = ParamSet$new(list(
           ParamInt$new("nfeat", lower = 1, tags = "generic"),
-          ParamDbl$new("perc", lower = 0, upper = 1, tags = "generic"),
+          ParamDbl$new("frac", lower = 0, upper = 1, tags = "generic"),
           ParamDbl$new("thresh", tags = "generic")
         )),
         param_vals = param_vals

--- a/R/FilterAUC.R
+++ b/R/FilterAUC.R
@@ -25,7 +25,7 @@ FilterAUC = R6Class("FilterAUC", inherit = Filter,
         task_type = "classif",
         task_properties = "twoclass",
         param_set = ParamSet$new(list(
-          ParamInt$new("abs", lower = 1, tags = "generic"),
+          ParamInt$new("nfeat", lower = 1, tags = "generic"),
           ParamDbl$new("perc", lower = 0, upper = 1, tags = "generic"),
           ParamDbl$new("thresh", tags = "generic")
         )),

--- a/R/FilterCMIM.R
+++ b/R/FilterCMIM.R
@@ -30,7 +30,7 @@ FilterCMIM = R6Class("FilterCMIM", inherit = Filter,
         param_set = ParamSet$new(list(
           ParamInt$new("k", lower = 1L, default = 3L, tags = "filter"),
           ParamInt$new("threads", lower = 0L, default = 0L, tags = "filter"),
-          ParamInt$new("abs", lower = 1, tags = "generic"),
+          ParamInt$new("nfeat", lower = 1, tags = "generic"),
           ParamDbl$new("perc", lower = 0, upper = 1, tags = "generic"),
           ParamDbl$new("thresh", tags = "generic")
         )),

--- a/R/FilterCMIM.R
+++ b/R/FilterCMIM.R
@@ -32,7 +32,7 @@ FilterCMIM = R6Class("FilterCMIM", inherit = Filter,
           ParamInt$new("threads", lower = 0L, default = 0L, tags = "filter"),
           ParamInt$new("nfeat", lower = 1, tags = "generic"),
           ParamDbl$new("frac", lower = 0, upper = 1, tags = "generic"),
-          ParamDbl$new("thresh", tags = "generic")
+          ParamDbl$new("cutoff", tags = "generic")
         )),
         param_vals = param_vals
       )

--- a/R/FilterCMIM.R
+++ b/R/FilterCMIM.R
@@ -31,7 +31,7 @@ FilterCMIM = R6Class("FilterCMIM", inherit = Filter,
           ParamInt$new("k", lower = 1L, default = 3L, tags = "filter"),
           ParamInt$new("threads", lower = 0L, default = 0L, tags = "filter"),
           ParamInt$new("nfeat", lower = 1, tags = "generic"),
-          ParamDbl$new("perc", lower = 0, upper = 1, tags = "generic"),
+          ParamDbl$new("frac", lower = 0, upper = 1, tags = "generic"),
           ParamDbl$new("thresh", tags = "generic")
         )),
         param_vals = param_vals

--- a/R/FilterCorrelation.R
+++ b/R/FilterCorrelation.R
@@ -29,7 +29,7 @@ FilterCorrelation = R6Class("FilterCorrelation", inherit = Filter,
             levels = c("pearson", "kendall", "spearman"), tags = "filter"),
           ParamInt$new("nfeat", lower = 1, tags = "generic"),
           ParamDbl$new("frac", lower = 0, upper = 1, tags = "generic"),
-          ParamDbl$new("thresh", tags = "generic")
+          ParamDbl$new("cutoff", tags = "generic")
         )),
         param_vals = param_vals
       )

--- a/R/FilterCorrelation.R
+++ b/R/FilterCorrelation.R
@@ -27,7 +27,7 @@ FilterCorrelation = R6Class("FilterCorrelation", inherit = Filter,
             tags = "filter"),
           ParamFct$new("method", default = "pearson",
             levels = c("pearson", "kendall", "spearman"), tags = "filter"),
-          ParamInt$new("abs", lower = 1, tags = "generic"),
+          ParamInt$new("nfeat", lower = 1, tags = "generic"),
           ParamDbl$new("perc", lower = 0, upper = 1, tags = "generic"),
           ParamDbl$new("thresh", tags = "generic")
         )),

--- a/R/FilterCorrelation.R
+++ b/R/FilterCorrelation.R
@@ -28,7 +28,7 @@ FilterCorrelation = R6Class("FilterCorrelation", inherit = Filter,
           ParamFct$new("method", default = "pearson",
             levels = c("pearson", "kendall", "spearman"), tags = "filter"),
           ParamInt$new("nfeat", lower = 1, tags = "generic"),
-          ParamDbl$new("perc", lower = 0, upper = 1, tags = "generic"),
+          ParamDbl$new("frac", lower = 0, upper = 1, tags = "generic"),
           ParamDbl$new("thresh", tags = "generic")
         )),
         param_vals = param_vals

--- a/R/FilterDISR.R
+++ b/R/FilterDISR.R
@@ -30,7 +30,7 @@ FilterDISR = R6Class("FilterDISR", inherit = Filter,
         param_set = ParamSet$new(list(
           ParamInt$new("k", lower = 1L, default = 3L, tags = "filter"),
           ParamInt$new("threads", lower = 0L, default = 0L, tags = "filter"),
-          ParamInt$new("abs", lower = 1, tags = "generic"),
+          ParamInt$new("nfeat", lower = 1, tags = "generic"),
           ParamDbl$new("perc", lower = 0, upper = 1, tags = "generic"),
           ParamDbl$new("thresh", tags = "generic")
         )),

--- a/R/FilterDISR.R
+++ b/R/FilterDISR.R
@@ -32,7 +32,7 @@ FilterDISR = R6Class("FilterDISR", inherit = Filter,
           ParamInt$new("threads", lower = 0L, default = 0L, tags = "filter"),
           ParamInt$new("nfeat", lower = 1, tags = "generic"),
           ParamDbl$new("frac", lower = 0, upper = 1, tags = "generic"),
-          ParamDbl$new("thresh", tags = "generic")
+          ParamDbl$new("cutoff", tags = "generic")
         )),
         param_vals = param_vals
       )

--- a/R/FilterDISR.R
+++ b/R/FilterDISR.R
@@ -31,7 +31,7 @@ FilterDISR = R6Class("FilterDISR", inherit = Filter,
           ParamInt$new("k", lower = 1L, default = 3L, tags = "filter"),
           ParamInt$new("threads", lower = 0L, default = 0L, tags = "filter"),
           ParamInt$new("nfeat", lower = 1, tags = "generic"),
-          ParamDbl$new("perc", lower = 0, upper = 1, tags = "generic"),
+          ParamDbl$new("frac", lower = 0, upper = 1, tags = "generic"),
           ParamDbl$new("thresh", tags = "generic")
         )),
         param_vals = param_vals

--- a/R/FilterEmbedded.R
+++ b/R/FilterEmbedded.R
@@ -31,7 +31,7 @@ FilterEmbedded = R6Class("FilterEmbedded", inherit = Filter,
         task_type = learner$task_type,
         param_set = ParamSet$new(list(
           ParamInt$new("nfeat", lower = 1, tags = "generic"),
-          ParamDbl$new("perc", lower = 0, upper = 1, tags = "generic"),
+          ParamDbl$new("frac", lower = 0, upper = 1, tags = "generic"),
           ParamDbl$new("thresh", tags = "generic")
         )),
         param_vals = param_vals

--- a/R/FilterEmbedded.R
+++ b/R/FilterEmbedded.R
@@ -30,7 +30,7 @@ FilterEmbedded = R6Class("FilterEmbedded", inherit = Filter,
         feature_types = learner$feature_types,
         task_type = learner$task_type,
         param_set = ParamSet$new(list(
-          ParamInt$new("abs", lower = 1, tags = "generic"),
+          ParamInt$new("nfeat", lower = 1, tags = "generic"),
           ParamDbl$new("perc", lower = 0, upper = 1, tags = "generic"),
           ParamDbl$new("thresh", tags = "generic")
         )),

--- a/R/FilterEmbedded.R
+++ b/R/FilterEmbedded.R
@@ -32,7 +32,7 @@ FilterEmbedded = R6Class("FilterEmbedded", inherit = Filter,
         param_set = ParamSet$new(list(
           ParamInt$new("nfeat", lower = 1, tags = "generic"),
           ParamDbl$new("frac", lower = 0, upper = 1, tags = "generic"),
-          ParamDbl$new("thresh", tags = "generic")
+          ParamDbl$new("cutoff", tags = "generic")
         )),
         param_vals = param_vals
       )

--- a/R/FilterGainRatio.R
+++ b/R/FilterGainRatio.R
@@ -28,7 +28,7 @@ FilterGainRatio = R6Class("FilterGainRatio", inherit = Filter,
           ParamLgl$new("equal", default = FALSE, tags = "filter"),
           ParamLgl$new("discIntegers", default = TRUE, tags = "filter"),
           ParamInt$new("threads", lower = 0L, default = 1L, tags = "filter"),
-          ParamInt$new("abs", lower = 1, tags = "generic"),
+          ParamInt$new("nfeat", lower = 1, tags = "generic"),
           ParamDbl$new("perc", lower = 0, upper = 1, tags = "generic"),
           ParamDbl$new("thresh", tags = "generic")
         )),

--- a/R/FilterGainRatio.R
+++ b/R/FilterGainRatio.R
@@ -30,7 +30,7 @@ FilterGainRatio = R6Class("FilterGainRatio", inherit = Filter,
           ParamInt$new("threads", lower = 0L, default = 1L, tags = "filter"),
           ParamInt$new("nfeat", lower = 1, tags = "generic"),
           ParamDbl$new("frac", lower = 0, upper = 1, tags = "generic"),
-          ParamDbl$new("thresh", tags = "generic")
+          ParamDbl$new("cutoff", tags = "generic")
         )),
         param_vals = param_vals
       )

--- a/R/FilterGainRatio.R
+++ b/R/FilterGainRatio.R
@@ -29,7 +29,7 @@ FilterGainRatio = R6Class("FilterGainRatio", inherit = Filter,
           ParamLgl$new("discIntegers", default = TRUE, tags = "filter"),
           ParamInt$new("threads", lower = 0L, default = 1L, tags = "filter"),
           ParamInt$new("nfeat", lower = 1, tags = "generic"),
-          ParamDbl$new("perc", lower = 0, upper = 1, tags = "generic"),
+          ParamDbl$new("frac", lower = 0, upper = 1, tags = "generic"),
           ParamDbl$new("thresh", tags = "generic")
         )),
         param_vals = param_vals

--- a/R/FilterInformationGain.R
+++ b/R/FilterInformationGain.R
@@ -28,7 +28,7 @@ FilterInformationGain = R6Class("FilterInformationGain", inherit = Filter,
           ParamLgl$new("equal", default = FALSE, tags = "filter"),
           ParamLgl$new("discIntegers", default = TRUE, tags = "filter"),
           ParamInt$new("threads", lower = 0L, default = 1L, tags = "filter"),
-          ParamInt$new("abs", lower = 1, tags = "generic"),
+          ParamInt$new("nfeat", lower = 1, tags = "generic"),
           ParamDbl$new("perc", lower = 0, upper = 1, tags = "generic"),
           ParamDbl$new("thresh", tags = "generic")
         )),

--- a/R/FilterInformationGain.R
+++ b/R/FilterInformationGain.R
@@ -30,7 +30,7 @@ FilterInformationGain = R6Class("FilterInformationGain", inherit = Filter,
           ParamInt$new("threads", lower = 0L, default = 1L, tags = "filter"),
           ParamInt$new("nfeat", lower = 1, tags = "generic"),
           ParamDbl$new("frac", lower = 0, upper = 1, tags = "generic"),
-          ParamDbl$new("thresh", tags = "generic")
+          ParamDbl$new("cutoff", tags = "generic")
         )),
         param_vals = param_vals
       )

--- a/R/FilterInformationGain.R
+++ b/R/FilterInformationGain.R
@@ -29,7 +29,7 @@ FilterInformationGain = R6Class("FilterInformationGain", inherit = Filter,
           ParamLgl$new("discIntegers", default = TRUE, tags = "filter"),
           ParamInt$new("threads", lower = 0L, default = 1L, tags = "filter"),
           ParamInt$new("nfeat", lower = 1, tags = "generic"),
-          ParamDbl$new("perc", lower = 0, upper = 1, tags = "generic"),
+          ParamDbl$new("frac", lower = 0, upper = 1, tags = "generic"),
           ParamDbl$new("thresh", tags = "generic")
         )),
         param_vals = param_vals

--- a/R/FilterJMI.R
+++ b/R/FilterJMI.R
@@ -31,7 +31,7 @@ FilterJMI = R6Class("FilterJMI", inherit = Filter,
           ParamInt$new("threads", lower = 0L, default = 0L, tags = "filter"),
           ParamInt$new("nfeat", lower = 1, tags = "generic"),
           ParamDbl$new("frac", lower = 0, upper = 1, tags = "generic"),
-          ParamDbl$new("thresh", tags = "generic")
+          ParamDbl$new("cutoff", tags = "generic")
         )),
         param_vals = param_vals
       )

--- a/R/FilterJMI.R
+++ b/R/FilterJMI.R
@@ -29,7 +29,7 @@ FilterJMI = R6Class("FilterJMI", inherit = Filter,
         param_set = ParamSet$new(list(
           ParamInt$new("k", lower = 1L, default = 3L, tags = "filter"),
           ParamInt$new("threads", lower = 0L, default = 0L, tags = "filter"),
-          ParamInt$new("abs", lower = 1, tags = "generic"),
+          ParamInt$new("nfeat", lower = 1, tags = "generic"),
           ParamDbl$new("perc", lower = 0, upper = 1, tags = "generic"),
           ParamDbl$new("thresh", tags = "generic")
         )),

--- a/R/FilterJMI.R
+++ b/R/FilterJMI.R
@@ -30,7 +30,7 @@ FilterJMI = R6Class("FilterJMI", inherit = Filter,
           ParamInt$new("k", lower = 1L, default = 3L, tags = "filter"),
           ParamInt$new("threads", lower = 0L, default = 0L, tags = "filter"),
           ParamInt$new("nfeat", lower = 1, tags = "generic"),
-          ParamDbl$new("perc", lower = 0, upper = 1, tags = "generic"),
+          ParamDbl$new("frac", lower = 0, upper = 1, tags = "generic"),
           ParamDbl$new("thresh", tags = "generic")
         )),
         param_vals = param_vals

--- a/R/FilterJMIM.R
+++ b/R/FilterJMIM.R
@@ -31,7 +31,7 @@ FilterJMIM = R6Class("FilterJMIM", inherit = Filter,
           ParamInt$new("k", lower = 1L, default = 3L, tags = "filter"),
           ParamInt$new("threads", lower = 0L, default = 0L, tags = "filter"),
           ParamInt$new("nfeat", lower = 1, tags = "generic"),
-          ParamDbl$new("perc", lower = 0, upper = 1, tags = "generic"),
+          ParamDbl$new("frac", lower = 0, upper = 1, tags = "generic"),
           ParamDbl$new("thresh", tags = "generic")
         )),
         param_vals = param_vals

--- a/R/FilterJMIM.R
+++ b/R/FilterJMIM.R
@@ -32,7 +32,7 @@ FilterJMIM = R6Class("FilterJMIM", inherit = Filter,
           ParamInt$new("threads", lower = 0L, default = 0L, tags = "filter"),
           ParamInt$new("nfeat", lower = 1, tags = "generic"),
           ParamDbl$new("frac", lower = 0, upper = 1, tags = "generic"),
-          ParamDbl$new("thresh", tags = "generic")
+          ParamDbl$new("cutoff", tags = "generic")
         )),
         param_vals = param_vals
       )

--- a/R/FilterJMIM.R
+++ b/R/FilterJMIM.R
@@ -30,7 +30,7 @@ FilterJMIM = R6Class("FilterJMIM", inherit = Filter,
         param_set = ParamSet$new(list(
           ParamInt$new("k", lower = 1L, default = 3L, tags = "filter"),
           ParamInt$new("threads", lower = 0L, default = 0L, tags = "filter"),
-          ParamInt$new("abs", lower = 1, tags = "generic"),
+          ParamInt$new("nfeat", lower = 1, tags = "generic"),
           ParamDbl$new("perc", lower = 0, upper = 1, tags = "generic"),
           ParamDbl$new("thresh", tags = "generic")
         )),

--- a/R/FilterKruskalTest.R
+++ b/R/FilterKruskalTest.R
@@ -26,7 +26,7 @@ FilterKruskalTest = R6Class("FilterKruskalTest", inherit = Filter,
           ParamFct$new("na.action", default = "na.omit",
             levels = c("na.omit", "na.fail", "na.exclude", "na.pass"), tags = "filter"),
           ParamInt$new("nfeat", lower = 1, tags = "generic"),
-          ParamDbl$new("perc", lower = 0, upper = 1, tags = "generic"),
+          ParamDbl$new("frac", lower = 0, upper = 1, tags = "generic"),
           ParamDbl$new("thresh", tags = "generic")
         )),
         param_vals = param_vals

--- a/R/FilterKruskalTest.R
+++ b/R/FilterKruskalTest.R
@@ -27,7 +27,7 @@ FilterKruskalTest = R6Class("FilterKruskalTest", inherit = Filter,
             levels = c("na.omit", "na.fail", "na.exclude", "na.pass"), tags = "filter"),
           ParamInt$new("nfeat", lower = 1, tags = "generic"),
           ParamDbl$new("frac", lower = 0, upper = 1, tags = "generic"),
-          ParamDbl$new("thresh", tags = "generic")
+          ParamDbl$new("cutoff", tags = "generic")
         )),
         param_vals = param_vals
       )

--- a/R/FilterKruskalTest.R
+++ b/R/FilterKruskalTest.R
@@ -25,7 +25,7 @@ FilterKruskalTest = R6Class("FilterKruskalTest", inherit = Filter,
         param_set = ParamSet$new(list(
           ParamFct$new("na.action", default = "na.omit",
             levels = c("na.omit", "na.fail", "na.exclude", "na.pass"), tags = "filter"),
-          ParamInt$new("abs", lower = 1, tags = "generic"),
+          ParamInt$new("nfeat", lower = 1, tags = "generic"),
           ParamDbl$new("perc", lower = 0, upper = 1, tags = "generic"),
           ParamDbl$new("thresh", tags = "generic")
         )),

--- a/R/FilterMIM.R
+++ b/R/FilterMIM.R
@@ -32,7 +32,7 @@ FilterMIM = R6Class("FilterMIM", inherit = Filter,
           ParamInt$new("threads", lower = 0L, default = 0L, tags = "filter"),
           ParamInt$new("nfeat", lower = 1, tags = "generic"),
           ParamDbl$new("frac", lower = 0, upper = 1, tags = "generic"),
-          ParamDbl$new("thresh", tags = "generic")
+          ParamDbl$new("cutoff", tags = "generic")
         )),
         param_vals = param_vals
       )

--- a/R/FilterMIM.R
+++ b/R/FilterMIM.R
@@ -30,7 +30,7 @@ FilterMIM = R6Class("FilterMIM", inherit = Filter,
         param_set = ParamSet$new(list(
           ParamInt$new("k", lower = 1L, default = 3L, tags = "filter"),
           ParamInt$new("threads", lower = 0L, default = 0L, tags = "filter"),
-          ParamInt$new("abs", lower = 1, tags = "generic"),
+          ParamInt$new("nfeat", lower = 1, tags = "generic"),
           ParamDbl$new("perc", lower = 0, upper = 1, tags = "generic"),
           ParamDbl$new("thresh", tags = "generic")
         )),

--- a/R/FilterMIM.R
+++ b/R/FilterMIM.R
@@ -31,7 +31,7 @@ FilterMIM = R6Class("FilterMIM", inherit = Filter,
           ParamInt$new("k", lower = 1L, default = 3L, tags = "filter"),
           ParamInt$new("threads", lower = 0L, default = 0L, tags = "filter"),
           ParamInt$new("nfeat", lower = 1, tags = "generic"),
-          ParamDbl$new("perc", lower = 0, upper = 1, tags = "generic"),
+          ParamDbl$new("frac", lower = 0, upper = 1, tags = "generic"),
           ParamDbl$new("thresh", tags = "generic")
         )),
         param_vals = param_vals

--- a/R/FilterMRMR.R
+++ b/R/FilterMRMR.R
@@ -32,7 +32,7 @@ FilterMRMR = R6Class("FilterMRMR", inherit = Filter,
           ParamInt$new("threads", lower = 0L, default = 0L, tags = "filter"),
           ParamInt$new("nfeat", lower = 1, tags = "generic"),
           ParamDbl$new("frac", lower = 0, upper = 1, tags = "generic"),
-          ParamDbl$new("thresh", tags = "generic")
+          ParamDbl$new("cutoff", tags = "generic")
         )),
         param_vals = param_vals
       )

--- a/R/FilterMRMR.R
+++ b/R/FilterMRMR.R
@@ -31,7 +31,7 @@ FilterMRMR = R6Class("FilterMRMR", inherit = Filter,
           ParamInt$new("k", lower = 1L, default = 3L, tags = "filter"),
           ParamInt$new("threads", lower = 0L, default = 0L, tags = "filter"),
           ParamInt$new("nfeat", lower = 1, tags = "generic"),
-          ParamDbl$new("perc", lower = 0, upper = 1, tags = "generic"),
+          ParamDbl$new("frac", lower = 0, upper = 1, tags = "generic"),
           ParamDbl$new("thresh", tags = "generic")
         )),
         param_vals = param_vals

--- a/R/FilterMRMR.R
+++ b/R/FilterMRMR.R
@@ -30,7 +30,7 @@ FilterMRMR = R6Class("FilterMRMR", inherit = Filter,
         param_set = ParamSet$new(list(
           ParamInt$new("k", lower = 1L, default = 3L, tags = "filter"),
           ParamInt$new("threads", lower = 0L, default = 0L, tags = "filter"),
-          ParamInt$new("abs", lower = 1, tags = "generic"),
+          ParamInt$new("nfeat", lower = 1, tags = "generic"),
           ParamDbl$new("perc", lower = 0, upper = 1, tags = "generic"),
           ParamDbl$new("thresh", tags = "generic")
         )),

--- a/R/FilterNJMIM.R
+++ b/R/FilterNJMIM.R
@@ -30,7 +30,7 @@ FilterNJMIM = R6Class("FilterNJMIM", inherit = Filter,
         param_set = ParamSet$new(list(
           ParamInt$new("k", lower = 1L, default = 3L, tags = "filter"),
           ParamInt$new("threads", lower = 0L, default = 0L, tags = "filter"),
-          ParamInt$new("abs", lower = 1, tags = "generic"),
+          ParamInt$new("nfeat", lower = 1, tags = "generic"),
           ParamDbl$new("perc", lower = 0, upper = 1, tags = "generic"),
           ParamDbl$new("thresh", tags = "generic")
         )),

--- a/R/FilterNJMIM.R
+++ b/R/FilterNJMIM.R
@@ -32,7 +32,7 @@ FilterNJMIM = R6Class("FilterNJMIM", inherit = Filter,
           ParamInt$new("threads", lower = 0L, default = 0L, tags = "filter"),
           ParamInt$new("nfeat", lower = 1, tags = "generic"),
           ParamDbl$new("frac", lower = 0, upper = 1, tags = "generic"),
-          ParamDbl$new("thresh", tags = "generic")
+          ParamDbl$new("cutoff", tags = "generic")
         )),
         param_vals = param_vals
       )

--- a/R/FilterNJMIM.R
+++ b/R/FilterNJMIM.R
@@ -31,7 +31,7 @@ FilterNJMIM = R6Class("FilterNJMIM", inherit = Filter,
           ParamInt$new("k", lower = 1L, default = 3L, tags = "filter"),
           ParamInt$new("threads", lower = 0L, default = 0L, tags = "filter"),
           ParamInt$new("nfeat", lower = 1, tags = "generic"),
-          ParamDbl$new("perc", lower = 0, upper = 1, tags = "generic"),
+          ParamDbl$new("frac", lower = 0, upper = 1, tags = "generic"),
           ParamDbl$new("thresh", tags = "generic")
         )),
         param_vals = param_vals

--- a/R/FilterSymmetricalUncertainty.R
+++ b/R/FilterSymmetricalUncertainty.R
@@ -30,7 +30,7 @@ FilterSymmetricalUncertainty = R6Class("FilterSymmetricalUncertainty", inherit =
           ParamInt$new("threads", lower = 0L, default = 1L, tags = "filter"),
           ParamInt$new("nfeat", lower = 1, tags = "generic"),
           ParamDbl$new("frac", lower = 0, upper = 1, tags = "generic"),
-          ParamDbl$new("thresh", tags = "generic")
+          ParamDbl$new("cutoff", tags = "generic")
         )),
         param_vals = param_vals
       )

--- a/R/FilterSymmetricalUncertainty.R
+++ b/R/FilterSymmetricalUncertainty.R
@@ -28,7 +28,7 @@ FilterSymmetricalUncertainty = R6Class("FilterSymmetricalUncertainty", inherit =
           ParamLgl$new("equal", default = FALSE, tags = "filter"),
           ParamLgl$new("discIntegers", default = TRUE, tags = "filter"),
           ParamInt$new("threads", lower = 0L, default = 1L, tags = "filter"),
-          ParamInt$new("abs", lower = 1, tags = "generic"),
+          ParamInt$new("nfeat", lower = 1, tags = "generic"),
           ParamDbl$new("perc", lower = 0, upper = 1, tags = "generic"),
           ParamDbl$new("thresh", tags = "generic")
         )),

--- a/R/FilterSymmetricalUncertainty.R
+++ b/R/FilterSymmetricalUncertainty.R
@@ -29,7 +29,7 @@ FilterSymmetricalUncertainty = R6Class("FilterSymmetricalUncertainty", inherit =
           ParamLgl$new("discIntegers", default = TRUE, tags = "filter"),
           ParamInt$new("threads", lower = 0L, default = 1L, tags = "filter"),
           ParamInt$new("nfeat", lower = 1, tags = "generic"),
-          ParamDbl$new("perc", lower = 0, upper = 1, tags = "generic"),
+          ParamDbl$new("frac", lower = 0, upper = 1, tags = "generic"),
           ParamDbl$new("thresh", tags = "generic")
         )),
         param_vals = param_vals

--- a/man/Filter.Rd
+++ b/man/Filter.Rd
@@ -57,17 +57,17 @@ values in a random order.
 Calculates the filter score values for the provided \link{Task}
 and stores them in field \code{scores}. Some filter support partial scoring via
 argument \code{n}.
-\item \code{filter_abs(task, abs)}\cr
+\item \code{filter_nfeat(task, nfeat)}\cr
 (\link{Task}, \code{integer(1)}) -> \link{Task}\cr
-Filters the \link{Task} by reference, keeps up to \code{abs} features.
-\item \code{filter_perc(task, perc)}\cr
+Filters the \link{Task} by reference, keeps up to \code{nfeat} features.
+\item \code{filter_frac(task, frac)}\cr
 (\link{Task}, \code{numeric(1)}) -> \link{Task}\cr
-Filters the \link{Task} by reference, keeps \code{perc} percent of the features
+Filters the \link{Task} by reference, keeps \code{frac} fracent of the features
 (rounded via \code{\link[base:round]{base::round()}}).
-\item \code{filter_thresh(task, thresh)}\cr
+\item \code{filter_cutoff(task, cutoff)}\cr
 (\link{Task}, \code{numeric(1)}) -> \link{Task}\cr
 Filters the \link{Task} by reference, keeps features whose filter score values
-exceeds \code{thresh}.
+exceeds \code{cutoff}.
 }
 }
 

--- a/tests/testthat/test_mlr_filters.R
+++ b/tests/testthat/test_mlr_filters.R
@@ -9,12 +9,12 @@ test_that("mlr_filters autotest", {
     if (task$task_type %in% f$task_type) {
       f$calculate(task)
       expect_filter_result(f, task = task)
-      new_task = f$filter_abs(task$clone(), 1)
+      new_task = f$filter_nfeat(task$clone(), 1)
       expect_string(new_task$feature_names)
 
       # try re-filtering
       f = mlr_filters$get(key)
-      f$calculate(new_task)$filter_abs(new_task, 1)
+      f$calculate(new_task)$filter_nfeat(new_task, 1)
     }
   }
 
@@ -24,12 +24,12 @@ test_that("mlr_filters autotest", {
     if (task$task_type %in% f$task_type) {
       f$calculate(task)
       expect_filter_result(f, task = task)
-      new_task = f$filter_abs(task$clone(), 1)
+      new_task = f$filter_nfeat(task$clone(), 1)
       expect_string(new_task$feature_names)
 
       # try re-filtering
       f = mlr_filters$get(key)
-      f$calculate(new_task)$filter_abs(new_task, 1)
+      f$calculate(new_task)$filter_nfeat(new_task, 1)
     }
   }
 })


### PR DESCRIPTION
It was [agreed](https://github.com/mlr-org/mlr3featsel/issues/14#issuecomment-507322778) on to change the hyperpars names. 

fixes #44 	